### PR TITLE
Shielded terminology

### DIFF
--- a/src/signEncryptedAmountTransfer.c
+++ b/src/signEncryptedAmountTransfer.c
@@ -13,7 +13,7 @@ UX_STEP_NOCB(
     ux_sign_encrypted_amount_transfer_1_step,
     nn,
     {
-      "Encrypted amount",
+      "Shielded",
       "transfer"
     });
 UX_STEP_CB(

--- a/src/signTransferToEncrypted.c
+++ b/src/signTransferToEncrypted.c
@@ -10,7 +10,7 @@ UX_STEP_NOCB(
     ux_sign_transfer_to_encrypted_1_step,
     bn_paging,
     {
-      .title = "Amount to enc.",
+      .title = "Amount to shield",
       .text = (char *) global.signTransferToEncrypted.amount
     });
 UX_FLOW(ux_sign_transfer_to_encrypted,

--- a/src/signTransferToEncrypted.c
+++ b/src/signTransferToEncrypted.c
@@ -10,7 +10,7 @@ UX_STEP_NOCB(
     ux_sign_transfer_to_encrypted_1_step,
     bn_paging,
     {
-      .title = "Amount to shield",
+      .title = "Shield amount",
       .text = (char *) global.signTransferToEncrypted.amount
     });
 UX_FLOW(ux_sign_transfer_to_encrypted,

--- a/src/signTransferToPublic.c
+++ b/src/signTransferToPublic.c
@@ -10,7 +10,7 @@ UX_STEP_NOCB(
     ux_sign_transfer_to_public_1_step,
     bn_paging,
     {
-      .title = "Amount to public",
+      .title = "Amount to unshield",
       .text = (char *) global.signTransferToPublic.amount
     });
 UX_FLOW(ux_sign_transfer_to_public,

--- a/src/signTransferToPublic.c
+++ b/src/signTransferToPublic.c
@@ -10,7 +10,7 @@ UX_STEP_NOCB(
     ux_sign_transfer_to_public_1_step,
     bn_paging,
     {
-      .title = "Amount to unshield",
+      .title = "Unshield amount",
       .text = (char *) global.signTransferToPublic.amount
     });
 UX_FLOW(ux_sign_transfer_to_public,


### PR DESCRIPTION
## Purpose

Use shielded terminology instead of encrypted/public on displays.

## Changes

Changed the text for amount displays for shielded transfer/shield/unshield.