### PR TITLE
Fix showing review transaction on cred deployment

### DIFF
--- a/src/signCredentialDeployment.c
+++ b/src/signCredentialDeployment.c
@@ -29,14 +29,6 @@ UX_STEP_CB(
       "details"
     });
 UX_STEP_CB(
-    ux_update_credentials_initial_flow_0_step,
-    nn,
-    sendSuccessNoIdle(),
-    {
-        "Review",
-            "transaction"
-            });
-UX_STEP_CB(
     ux_update_credentials_initial_flow_1_step,
     nn,
     sendSuccessNoIdle(),
@@ -49,7 +41,7 @@ UX_FLOW(ux_credential_deployment_initial_flow,
 );
 
 UX_FLOW(ux_update_credentials_initial_flow,
-    &ux_update_credentials_initial_flow_0_step,
+    &ux_sign_flow_shared_review,
     &ux_sign_flow_account_sender_view,
     &ux_update_credentials_initial_flow_1_step
 );

--- a/src/signCredentialDeployment.c
+++ b/src/signCredentialDeployment.c
@@ -155,8 +155,8 @@ UX_FLOW(ux_sign_credential_deployment_existing,
 );
 
 UX_FLOW(ux_sign_credential_deployment_new,
-        &ux_sign_credential_deployment_1_step,
-        &ux_sign_credential_deployment_2_step
+    &ux_sign_credential_deployment_1_step,
+    &ux_sign_credential_deployment_2_step
     );
 
 UX_STEP_CB(
@@ -396,7 +396,7 @@ void handleSignCredentialDeployment(uint8_t *dataBuffer, uint8_t p1, uint8_t p2,
     } else if (p1 == P1_AR_IDENTITY && ctx->state == TX_CREDENTIAL_DEPLOYMENT_AR_IDENTITY) {
         if (ctx->anonymityRevocationListLength == 0) {
              // Invalid state, sender says ar identity pair is incoming, but we already received all.
-            THROW(ERROR_INVALID_STATE); 
+            THROW(ERROR_INVALID_STATE);
         }
 
         // Parse ArIdentity


### PR DESCRIPTION
## Purpose

Currently signing credentials for credential deployment is called a transaction in the UI.
`Review Transaction`, `Sign Transaction` and `Decline to sign Transaction`.
This PR replaces `transaction` with `details`.

Fixes #8.

## Changes

Changes some UI elements in SignCredentialDeployment, to replace `transaction` with `details` in credential deployment only.
Changes credential_deployment test to allow sending credential from new or existing accounts.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
