### PR TITLE
Split pages consistently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Improved state validation to deny instruction changes in multi command transactions.
 * Support building for the Ledger Nano X.
+* Changed Hex and Base58Check functions to ensure splitting pages evenly and consistently.
 
 ## 1.0.2
 

--- a/src/base58check.c
+++ b/src/base58check.c
@@ -4,7 +4,7 @@
 *
 *  - Only the 'base58_encode()' method (renamed from btchip_encode_base58).
 *    Reformatting of the method has been done, and removal of all PRINTF()
-*    invocations, and changed the algoritm to insert a space for every 10 characters.
+*    invocations, and changed the algorithm to insert a space for every 10 characters.
 *
 *  Licensed under the Apache License, Version 2.0 (the "License");
 *  you may not use this file except in compliance with the License.

--- a/src/base58check.c
+++ b/src/base58check.c
@@ -4,7 +4,7 @@
 *
 *  - Only the 'base58_encode()' method (renamed from btchip_encode_base58).
 *    Reformatting of the method has been done, and removal of all PRINTF()
-*    invocations.
+*    invocations, and changed the algoritm to insert a space for every 10 characters.
 *
 *  Licensed under the Apache License, Version 2.0 (the "License");
 *  you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ int base58_encode(const unsigned char *in, size_t length, unsigned char *out, si
     size_t startAt, stopAt;
     size_t zeroCount = 0;
     size_t outputSize;
+    size_t pageSize = 10;
 
     if (length > MAX_ENC_INPUT_SIZE) {
         return -1;
@@ -48,6 +49,8 @@ int base58_encode(const unsigned char *in, size_t length, unsigned char *out, si
     }
 
     outputSize = (length - zeroCount) * 138 / 100 + 1;
+    int spaces = outputSize / pageSize;
+    outputSize += spaces;
     if (*outlen < outputSize) {
         *outlen = outputSize;
         return -1;
@@ -81,14 +84,28 @@ int base58_encode(const unsigned char *in, size_t length, unsigned char *out, si
 
     *outlen = zeroCount + outputSize - j;
     int distance = zeroCount - j;
+    size_t nextSpace = pageSize;
+    int offset = 0;
     if (distance < 0) {
-        for (i = zeroCount; i < *outlen; ++i) {
-            out[i] = BASE58ALPHABET[out[i - distance]];
+        for (i = zeroCount; i < *outlen + spaces; ++i) {
+            if (i == nextSpace) {
+                out[i] = ' ';
+                nextSpace += (pageSize + 1);
+                offset++;
+            } else {
+                out[i] = BASE58ALPHABET[out[i - distance - offset]];
+            }
         }
     }
     else {
-        for (i = *outlen - 1; (int)i >= 0; --i) {
-            out[i] = BASE58ALPHABET[out[i - distance]];
+        for (i = *outlen + spaces - 1; (int)i >= 0; --i) {
+            if  ((*outlen - 1 - i) == nextSpace) {
+                out[i] = ' ';
+                nextSpace += (pageSize + 1);
+                offset++;
+            } else {
+                out[i] = BASE58ALPHABET[out[i - distance + offset]];
+            }
         }
     }
 

--- a/src/base58check.c
+++ b/src/base58check.c
@@ -99,7 +99,7 @@ int base58_encode(const unsigned char *in, size_t length, unsigned char *out, si
     }
     else {
         for (i = *outlen + spaces - 1; (int)i >= 0; --i) {
-            if  ((*outlen - 1 - i) == nextSpace) {
+            if  ((*outlen + spaces - 1 - i) == nextSpace) {
                 out[i] = ' ';
                 nextSpace += (pageSize + 1);
                 offset++;

--- a/src/base58check.h
+++ b/src/base58check.h
@@ -4,8 +4,9 @@
 int encode_base58(const unsigned char *in, size_t length, unsigned char *out, size_t *outlen);
 
 /**
- * Base58 encodes the input and writes the encoding to the supplied out destination. Returns a 
+ * Base58 encodes the input and writes the encoding to the supplied out destination. Returns a
  * non-zero value if the input cannot be validly base58 encoded, i.e. the input is malformed.
+ * N.B. The encoding contains a space for every 10th character.
  * @return 0 if input was validly base58 encoded, or -1 if it was not valid base58
  */
 int base58check_encode(const unsigned char *in, size_t length, unsigned char *out, size_t *outlen);

--- a/src/getPublicKey.c
+++ b/src/getPublicKey.c
@@ -79,7 +79,7 @@ void sendPublicKey(bool compare) {
     if (compare) {
         // Show the public-key so that the user can verify the public-key.
         sendSuccessResultNoIdle(tx);
-        toHex(publicKey, sizeof(publicKey), ctx->publicKey);
+        toPaginatedHex(publicKey, sizeof(publicKey), ctx->publicKey);
         // Allow for receiving a new instruction even while comparing public keys.
         tx_state->currentInstruction = -1;
         ux_flow_init(0, ux_sign_compare_public_key, NULL);    

--- a/src/getPublicKey.h
+++ b/src/getPublicKey.h
@@ -13,7 +13,7 @@ void handleGetPublicKey(uint8_t *cdata, uint8_t p1, uint8_t p2, volatile unsigne
 
 typedef struct { 
     uint8_t display[14];
-    char publicKey[64];
+    char publicKey[68];
     bool signPublicKey;
 } exportPublicKeyContext_t;
 

--- a/src/globals.h
+++ b/src/globals.h
@@ -103,7 +103,7 @@ extern tx_state_t global_tx_state;
 // Helper struct that is used to hold the account sender
 // address from an account transaction header.
 typedef struct {
-    uint8_t sender[52];
+    uint8_t sender[57];
 } accountSender_t;
 extern accountSender_t global_account_sender;
 

--- a/src/main.c
+++ b/src/main.c
@@ -19,6 +19,7 @@
 #include "os.h"
 #include "cx.h"
 #include "os_io_seproxyhal.h"
+#include <stdbool.h>
 #include "menu.h"
 #include "getPublicKey.h"
 #include "signTransfer.h"

--- a/src/signCredentialDeployment.c
+++ b/src/signCredentialDeployment.c
@@ -533,7 +533,7 @@ void handleSignCredentialDeployment(uint8_t *dataBuffer, uint8_t p1, uint8_t p2,
             // The received address bytes are not a valid base58 encoding.
                 THROW(ERROR_INVALID_TRANSACTION);  
             }
-            ctx->accountAddress[50] = '\0';
+            ctx->accountAddress[55] = '\0';
 
             cx_hash((cx_hash_t *) &tx_state->hash, 0, dataBuffer, 32, NULL, 0);
             ux_flow_init(0, ux_sign_credential_deployment, NULL);

--- a/src/signCredentialDeployment.c
+++ b/src/signCredentialDeployment.c
@@ -217,7 +217,7 @@ void parseVerificationKey(uint8_t *buffer) {
     cx_hash((cx_hash_t *) &tx_state->hash, 0, verificationKey, 32, NULL, 0);
 
     // Convert to a human-readable format.
-    toHex(verificationKey, sizeof(verificationKey), ctx->accountVerificationKey);
+    toPaginatedHex(verificationKey, sizeof(verificationKey), ctx->accountVerificationKey);
     ctx->numberOfVerificationKeys -= 1;
 
     // Show to the user.
@@ -289,7 +289,7 @@ void handleSignUpdateCredential(uint8_t *dataBuffer, uint8_t p1, uint8_t p2, vol
         sendSuccessNoIdle();
     } else if (p2 == P2_CREDENTIAL_ID && ctx->updateCredentialState == TX_UPDATE_CREDENTIAL_ID) {
         cx_hash((cx_hash_t *) &tx_state->hash, 0, dataBuffer, 48, NULL, 0);
-        toHex(dataBuffer, 48, ctx->credentialId);
+        toPaginatedHex(dataBuffer, 48, ctx->credentialId);
 
         ctx->credentialIdCount -= 1;
         if (ctx->credentialIdCount == 0) {
@@ -351,7 +351,7 @@ void handleSignCredentialDeployment(uint8_t *dataBuffer, uint8_t p1, uint8_t p2,
         uint8_t regIdCred[48];
         memmove(regIdCred, dataBuffer, 48);
         dataBuffer += 48;
-        toHex(regIdCred, sizeof(regIdCred), ctx->regIdCred);
+        toPaginatedHex(regIdCred, sizeof(regIdCred), ctx->regIdCred);
         cx_hash((cx_hash_t *) &tx_state->hash, 0, regIdCred, 48, NULL, 0);
 
         // Parse identity provider identity.
@@ -395,7 +395,7 @@ void handleSignCredentialDeployment(uint8_t *dataBuffer, uint8_t p1, uint8_t p2,
         // Parse enc_id_cred_pub_share
         uint8_t encIdCredPubShare[96];
         memmove(encIdCredPubShare, dataBuffer, 96);
-        toHex(encIdCredPubShare, sizeof(encIdCredPubShare), ctx->encIdCredPubShare);
+        toPaginatedHex(encIdCredPubShare, sizeof(encIdCredPubShare), ctx->encIdCredPubShare);
         cx_hash((cx_hash_t *) &tx_state->hash, 0, encIdCredPubShare, 96, NULL, 0);
         dataBuffer += 96;
 
@@ -476,7 +476,7 @@ void handleSignCredentialDeployment(uint8_t *dataBuffer, uint8_t p1, uint8_t p2,
         if (ctx->attributeListLength == 0) {
             uint8_t attributeHashBytes[32];
             cx_hash((cx_hash_t *) &attributeHash, CX_LAST, NULL, 0, attributeHashBytes, 32);
-            toHex(attributeHashBytes, sizeof(attributeHashBytes), ctx->attributeHashDisplay);
+            toPaginatedHex(attributeHashBytes, sizeof(attributeHashBytes), ctx->attributeHashDisplay);
             ctx->state = TX_CREDENTIAL_DEPLOYMENT_LENGTH_OF_PROOFS;
             sendSuccessNoIdle();
         } else {

--- a/src/signCredentialDeployment.h
+++ b/src/signCredentialDeployment.h
@@ -51,7 +51,7 @@ typedef struct {
     uint16_t anonymityRevocationListLength;
 
     uint8_t arIdentity[11];
-    char96encIdCredPubShare[204];
+    char encIdCredPubShare[204];
 
     uint8_t validTo[8];
     uint8_t createdAt[8];

--- a/src/signCredentialDeployment.h
+++ b/src/signCredentialDeployment.h
@@ -37,13 +37,13 @@ typedef struct {
 
     uint8_t credentialDeploymentCount;
     uint8_t credentialIdCount;
-    char credentialId[97];
+    char credentialId[102];
     uint8_t threshold[4];
     updateCredentialState_t updateCredentialState;
 
-    char accountVerificationKey[65];
+    char accountVerificationKey[68];
     uint8_t signatureThreshold[4];
-    char regIdCred[97];
+    char regIdCred[102];
 
     uint8_t identityProviderIdentity[4];
     uint8_t anonymityRevocationThreshold[4];
@@ -51,7 +51,7 @@ typedef struct {
     uint16_t anonymityRevocationListLength;
 
     uint8_t arIdentity[11];
-    char encIdCredPubShare[192];
+    char96encIdCredPubShare[204];
 
     uint8_t validTo[8];
     uint8_t createdAt[8];
@@ -60,7 +60,7 @@ typedef struct {
 
     cx_sha256_t attributeHash;
     uint8_t attributeValueLength;
-    char attributeHashDisplay[65];
+    char attributeHashDisplay[68];
 
     uint32_t proofLength;
     uint8_t accountAddress[52];

--- a/src/signCredentialDeployment.h
+++ b/src/signCredentialDeployment.h
@@ -63,7 +63,7 @@ typedef struct {
     char attributeHashDisplay[68];
 
     uint32_t proofLength;
-    uint8_t accountAddress[52];
+    uint8_t accountAddress[57];
 
     protocolState_t state;
 } signCredentialDeploymentContext_t;

--- a/src/signEncryptedAmountTransfer.c
+++ b/src/signEncryptedAmountTransfer.c
@@ -59,7 +59,7 @@ void handleSignEncryptedAmountTransfer(uint8_t *cdata, uint8_t p1, uint8_t dataL
             // The received address bytes are not valid a valid base58 encoding.
             THROW(ERROR_INVALID_TRANSACTION);
         }
-        ctx->to[50] = '\0';
+        ctx->to[55] = '\0';
 
         ctx->state = TX_ENCRYPTED_AMOUNT_TRANSFER_REMAINING_AMOUNT;
         sendSuccessNoIdle();

--- a/src/signEncryptedAmountTransfer.h
+++ b/src/signEncryptedAmountTransfer.h
@@ -15,8 +15,8 @@ typedef enum {
     TX_ENCRYPTED_AMOUNT_TRANSFER_PROOFS = 18
 } encryptedAmountTransferState_t;
 
-typedef struct { 
-    uint8_t to[52];
+typedef struct {
+    uint8_t to[57];
     uint16_t proofSize;
     encryptedAmountTransferState_t state;
 } signEncryptedAmountToTransfer_t;

--- a/src/signHigherLevelKeyUpdate.c
+++ b/src/signHigherLevelKeyUpdate.c
@@ -97,7 +97,7 @@ void handleSignHigherLevelKeys(uint8_t *cdata, uint8_t p1, uint8_t updateType, v
         cx_hash((cx_hash_t *) &tx_state->hash, 0, cdata, 1, NULL, 0);
         cdata += 1;
 
-        toHex(cdata, 32, ctx->updateVerificationKey);
+        toPaginatedHex(cdata, 32, ctx->updateVerificationKey);
         cx_hash((cx_hash_t *) &tx_state->hash, 0, cdata, 32, NULL, 0);
         cdata += 32;
 

--- a/src/signHigherLevelKeyUpdate.h
+++ b/src/signHigherLevelKeyUpdate.h
@@ -42,7 +42,7 @@ typedef enum {
 typedef struct {
     uint8_t type[25];
     uint16_t numberOfUpdateKeys;
-    char updateVerificationKey[65];
+    char updateVerificationKey[68];
     uint8_t threshold[6];
     updateKeysState_t state;
 } signUpdateKeysWithRootKeysContext_t;

--- a/src/signPublicInformationForIp.c
+++ b/src/signPublicInformationForIp.c
@@ -72,14 +72,14 @@ void handleSignPublicInformationForIp(uint8_t *cdata, uint8_t p1, volatile unsig
         memmove(idCredPub, cdata, 48);
         cx_hash((cx_hash_t *) &tx_state->hash, 0, idCredPub, 48, NULL, 0);
         cdata += 48;
-        toHex(idCredPub, 48, ctx->idCredPub);
+        toPaginatedHex(idCredPub, 48, ctx->idCredPub);
 
         // Parse cred_id so it can be displayed.
         uint8_t credId[48];
         memmove(credId, cdata, 48);
         cx_hash((cx_hash_t *) &tx_state->hash, 0, credId, 48, NULL, 0);
         cdata += 48;
-        toHex(credId, 48, ctx->credId);
+        toPaginatedHex(credId, 48, ctx->credId);
 
         // Parse number of public-keys that will be received next.
         ctx->publicKeysLength = cdata[0];
@@ -105,7 +105,7 @@ void handleSignPublicInformationForIp(uint8_t *cdata, uint8_t p1, volatile unsig
         memmove(publicKey, cdata, 32);
         cx_hash((cx_hash_t *) &tx_state->hash, 0, publicKey, 32, NULL, 0);
         cdata += 32;
-        toHex(publicKey, 32, ctx->publicKey);
+        toPaginatedHex(publicKey, 32, ctx->publicKey);
 
         ctx->publicKeysLength -= 1;
         if (ctx->publicKeysLength == 0) {

--- a/src/signPublicInformationForIp.h
+++ b/src/signPublicInformationForIp.h
@@ -16,10 +16,10 @@ typedef enum {
 } publicInfoForIpState_t;
 
 typedef struct {
-    char credId[97];
-    char idCredPub[97];
+    char credId[102];
+    char idCredPub[102];
     uint8_t publicKeysLength;
-    char publicKey[65];
+    char publicKey[68];
     uint8_t threshold[4];
     publicInfoForIpState_t state;
 } signPublicInformationForIp_t;

--- a/src/signTransfer.c
+++ b/src/signTransfer.c
@@ -53,9 +53,9 @@ void handleSignTransfer(uint8_t *cdata, volatile unsigned int *flags) {
     size_t outputSize = sizeof(ctx->displayStr);
     if (base58check_encode(toAddress, sizeof(toAddress), ctx->displayStr, &outputSize) != 0) {
       // The received address bytes are not a valid base58 encoding.
-        THROW(ERROR_INVALID_TRANSACTION);  
+        THROW(ERROR_INVALID_TRANSACTION);
     }
-    ctx->displayStr[50] = '\0';
+    ctx->displayStr[55] = '\0';
 
     // Build display value of the amount to transfer, and also add the bytes to the hash.
     uint64_t amount = U8BE(cdata, 0);

--- a/src/signTransfer.h
+++ b/src/signTransfer.h
@@ -9,7 +9,7 @@
 void handleSignTransfer(uint8_t *cdata, volatile unsigned int *flags);
 
 typedef struct {
-    unsigned char displayStr[52];
+    unsigned char displayStr[57];
     uint8_t displayAmount[26];
 } signTransferContext_t;
 

--- a/src/signTransferWithSchedule.c
+++ b/src/signTransferWithSchedule.c
@@ -135,7 +135,7 @@ void handleSignTransferWithSchedule(uint8_t *cdata, uint8_t p1, volatile unsigne
         if (base58check_encode(toAddress, sizeof(toAddress), ctx->displayStr, &outputSize) != 0) {
             THROW(ERROR_INVALID_TRANSACTION);
         }
-        ctx->displayStr[50] = '\0';
+        ctx->displayStr[55] = '\0';
 
         // Store the number of scheduled amounts we are going to receive next.
         ctx->remainingNumberOfScheduledAmounts = cdata[0];

--- a/src/signTransferWithSchedule.h
+++ b/src/signTransferWithSchedule.h
@@ -20,7 +20,7 @@ typedef enum {
 typedef struct {
     transferWithScheduleState_t state;
 
-    unsigned char displayStr[52];
+    unsigned char displayStr[57];
     uint8_t remainingNumberOfScheduledAmounts;
     uint8_t scheduledAmountsInCurrentPacket;
 

--- a/src/signUpdateAuthorizations.c
+++ b/src/signUpdateAuthorizations.c
@@ -176,7 +176,7 @@ void handleSignUpdateAuthorizations(uint8_t *cdata, uint8_t p1, uint8_t updateTy
 
         uint8_t publicKeyInput[32];
         memmove(publicKeyInput, cdata, 32);
-        toHex(publicKeyInput, 32, ctx->publicKey);
+        toPaginatedHex(publicKeyInput, 32, ctx->publicKey);
         cx_hash((cx_hash_t *) &tx_state->hash, 0, publicKeyInput, 32, NULL, 0);
 
         ctx->publicKeyListLength -= 1;

--- a/src/signUpdateAuthorizations.h
+++ b/src/signUpdateAuthorizations.h
@@ -43,7 +43,7 @@ typedef enum {
 typedef struct {
     uint16_t publicKeyListLength;
     uint16_t publicKeyCount;
-    char publicKey[65];
+    char publicKey[68];
     uint16_t accessStructureSize;
     uint8_t title[29];
     uint8_t displayKeyIndex[6];

--- a/src/signUpdateFoundationAccount.c
+++ b/src/signUpdateFoundationAccount.c
@@ -40,7 +40,7 @@ void handleSignUpdateFoundationAccount(uint8_t *cdata, volatile unsigned int *fl
       // The received address bytes were not valid a valid base58 encoding, so the transaction is invalid.
         THROW(ERROR_INVALID_TRANSACTION);
     }
-    ctx->foundationAccountAddress[50] = '\0';
+    ctx->foundationAccountAddress[55] = '\0';
 
     ux_flow_init(0, ux_sign_foundation_account_address, NULL);
     *flags |= IO_ASYNCH_REPLY;

--- a/src/signUpdateFoundationAccount.h
+++ b/src/signUpdateFoundationAccount.h
@@ -9,7 +9,7 @@
 void handleSignUpdateFoundationAccount(uint8_t *cdata, volatile unsigned int *flags);
 
 typedef struct {
-    uint8_t foundationAccountAddress[52];
+    uint8_t foundationAccountAddress[57];
 } signUpdateFoundationAccountContext_t;
 
 #endif

--- a/src/signUpdateProtocol.c
+++ b/src/signUpdateProtocol.c
@@ -122,7 +122,7 @@ void handleSignUpdateProtocol(uint8_t *cdata, uint8_t p1, uint8_t dataLength, vo
         *flags |= IO_ASYNCH_REPLY;
     } else if (p1 == P1_SPECIFICATION_HASH && ctx->state == TX_UPDATE_PROTOCOL_SPECIFICATION_HASH) {
         cx_hash((cx_hash_t *) &tx_state->hash, 0, cdata, 32, NULL, 0);
-        toHex(cdata, 32, ctx->specificationHash);
+        toPaginatedHex(cdata, 32, ctx->specificationHash);
         ctx->payloadLength -= 32;
 
         ctx->state = TX_UPDATE_PROTOCOL_AUXILIARY_DATA;

--- a/src/signUpdateProtocol.h
+++ b/src/signUpdateProtocol.h
@@ -28,7 +28,7 @@ typedef struct {
     uint8_t buffer[255];
     textState_t textState;
     updateProtocolState_t state;
-    char specificationHash[65];
+    char specificationHash[68];
 } signUpdateProtocolContext_t;
 
 #endif

--- a/src/util.c
+++ b/src/util.c
@@ -253,13 +253,21 @@ void sendSuccessResultNoIdle(uint8_t tx) {
     io_exchange(CHANNEL_APDU | IO_RETURN_AFTER_TX, tx);
 }
 
-void toHex(uint8_t *byteArray, const uint64_t len, char *asHex) {
+void toPaginatedHex(uint8_t *byteArray, const uint64_t len, char *asHex) {
     static uint8_t const hex[] = "0123456789abcdef";
+    uint8_t offset = 0;
     for (uint64_t i = 0; i < len; i++) {
-        asHex[2 * i + 0] = hex[(byteArray[i]>>4) & 0x0F];
-        asHex[2 * i + 1] = hex[(byteArray[i]>>0) & 0x0F];
+        asHex[2 * i + offset] = hex[(byteArray[i]>>4) & 0x0F];
+        asHex[2 * i + (offset + 1)] = hex[(byteArray[i]>>0) & 0x0F];
+
+        // Insert a space to force the Ledger to paginate the string every
+        // 16 characters.
+        if ((2 * (i + 1)) % 16 == 0 && i != len - 1) {
+            asHex[2 * i + (offset + 2)] = ' ';
+            offset += 1;
+        }
     }
-    asHex[2 * len] = '\0';
+    asHex[2 * len + offset] = '\0';
 }
 
 void getPrivateKey(uint32_t *keyPath, uint8_t keyPathLength, cx_ecfp_private_key_t *privateKey) {

--- a/src/util.c
+++ b/src/util.c
@@ -213,9 +213,9 @@ int hashAccountTransactionHeaderAndKind(uint8_t *cdata, uint8_t validTransaction
     size_t outputSize = sizeof(accountSender->sender);
     if (base58check_encode(cdata, 32, accountSender->sender, &outputSize) != 0) {
         // The received address bytes are not a valid base58 encoding.
-        THROW(ERROR_INVALID_TRANSACTION);  
+        THROW(ERROR_INVALID_TRANSACTION);
     }
-    accountSender->sender[50] = '\0';
+    accountSender->sender[55] = '\0';
 
     return hashHeaderAndType(cdata, ACCOUNT_TRANSACTION_HEADER_LENGTH, validTransactionKind);
 }

--- a/src/util.h
+++ b/src/util.h
@@ -89,12 +89,14 @@ void getPublicKey(uint8_t *publicKeyArray);
 /**
  * Helper method for converting a byte array into a character array, where the bytes
  * are translated into their hexadecimal representation. This is used for getting human-readable
- * representations of e.g. keys and credential ids.
- * @param byteArray [in] the bytes to convert to hex
- * @param len the length of 'byteArray', i.e. the number of bytes to convert to hex
+ * representations of e.g. keys and credential ids. The output array is 'paginated' by inserting
+ * a space after 16 characters, as this will make the Ledger pagination change page after 
+ * 16 characters.
+ * @param byteArray [in] the bytes to convert to paginated hex
+ * @param len the length of 'byteArray', i.e. the number of bytes to convert to paginated hex
  * @param asHex [out] where to write the output hexadecimal characters
  */
-void toHex(uint8_t *byteArray, const uint64_t len, char *asHex);
+void toPaginatedHex(uint8_t *byteArray, const uint64_t len, char *asHex);
 
 /**
  * Parses the key derivation path for the command to be executed. This method should


### PR DESCRIPTION
## Purpose

Fixes #5, By separating Hex strings in 16 sized chunks and base58check addresses in 10 sized Chunks, by inserting spaces, when displaying them.

## Changes

Changed the base58_encode function to insert spaces between every 10th character.
Changed toHex (renamed toPaginatedHex) to insert spaces between every 16th character.
Adjusted sizes of context that stores hex strings/addresses to compensate for the spaces. 


## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
