### PR TITLE
Handle empty description in addIdentityProvider

### DIFF
--- a/src/signAddIdentityProvider.c
+++ b/src/signAddIdentityProvider.c
@@ -93,21 +93,21 @@ UX_FLOW(ux_sign_add_identity_provider_finish,
 void handleDescriptionPart(void) {
     if (ctx->textLength == 0) {
         switch (ctx->descriptionState) {
-        case NAME:
-            ctx->state = TX_ADD_IDENTITY_PROVIDER_DESCRIPTION_LENGTH;
-            ctx->descriptionState = URL;
-            break;
-        case URL:
-            ctx->state = TX_ADD_IDENTITY_PROVIDER_DESCRIPTION_LENGTH;
-            ctx->descriptionState = DESCRIPTION;
-            break;
-        case DESCRIPTION:
-            ctx->state = TX_ADD_IDENTITY_PROVIDER_VERIFY_KEY;
-            ctx->verifyKeyLength = ctx->payloadLength - CDI_VERIFY_KEY_LENGTH;
-            break;
-        default:
-            THROW(ERROR_INVALID_STATE);
-            break;
+            case NAME:
+                ctx->state = TX_ADD_IDENTITY_PROVIDER_DESCRIPTION_LENGTH;
+                ctx->descriptionState = URL;
+                break;
+            case URL:
+                ctx->state = TX_ADD_IDENTITY_PROVIDER_DESCRIPTION_LENGTH;
+                ctx->descriptionState = DESCRIPTION;
+                break;
+            case DESCRIPTION:
+                ctx->state = TX_ADD_IDENTITY_PROVIDER_VERIFY_KEY;
+                ctx->verifyKeyLength = ctx->payloadLength - CDI_VERIFY_KEY_LENGTH;
+                break;
+            default:
+                THROW(ERROR_INVALID_STATE);
+                break;
         }
     }
     sendSuccessNoIdle();
@@ -149,21 +149,8 @@ void handleSignAddIdentityProvider(uint8_t *cdata, uint8_t p1, uint8_t dataLengt
         cx_hash((cx_hash_t *) &tx_state->hash, 0, cdata, 4, NULL, 0);
         ctx->payloadLength -= 4;
 
-        if (ctx->textLength == 0) {
-            // The description is optional, so handle it having length = 0, The other parts are not optional, so throw an error in those cases.
-            switch (ctx->descriptionState) {
-                case DESCRIPTION:
-                    ctx->state = TX_ADD_IDENTITY_PROVIDER_VERIFY_KEY;
-                    ctx->verifyKeyLength = ctx->payloadLength - CDI_VERIFY_KEY_LENGTH;
-                    break;
-                default:
-                    THROW(ERROR_INVALID_PARAM);
-                    break;
-            }
-        } else {
-            ctx->state = TX_ADD_IDENTITY_PROVIDER_DESCRIPTION;
-        }
-        sendSuccessNoIdle();
+        ctx->state = TX_ADD_IDENTITY_PROVIDER_DESCRIPTION;
+        handleDescriptionPart();
     } else if (p1 == P1_DESCRIPTION && ctx->state == TX_ADD_IDENTITY_PROVIDER_DESCRIPTION) {
         cx_hash((cx_hash_t *) &tx_state->hash, 0, cdata, dataLength, NULL, 0);
 


### PR DESCRIPTION
## Purpose

Fix the bug where in the AddIdentityProvider update, if an empty description is given, the app throws an error.

## Changes

Add handling of empty description (skip the step where we receive the description data). 

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
