### PR TITLE
Remove GTU from display when signing a transfer

### DIFF
--- a/src/signTransfer.c
+++ b/src/signTransfer.c
@@ -10,10 +10,7 @@ static signTransferContext_t *ctx = &global.withMemo.signTransferContext;
 static memoContext_t *memo_ctx = &global.withMemo.memoContext;
 static tx_state_t *tx_state = &global_tx_state;
 
-UX_STEP_NOCB(
-    ux_sign_flow_1_step,
-    bnnn_paging,
-    {"Amount (GTU)", (char *) global.withMemo.signTransferContext.displayAmount});
+UX_STEP_NOCB(ux_sign_flow_1_step, bnnn_paging, {"Amount", (char *) global.withMemo.signTransferContext.displayAmount});
 
 UX_STEP_NOCB(
     ux_sign_flow_2_step,


### PR DESCRIPTION
## Purpose

Remove display of the word "GTU", except for in chain updates

## Changes

Changed _Amount (GTU)_ to _Amount_ in simple transfer display.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.