### PR TITLE
Fix register data full blob + dataLength's size

### DIFF
--- a/src/signRegisterData.c
+++ b/src/signRegisterData.c
@@ -85,8 +85,12 @@ void handleSignRegisterData(
                 THROW(ERROR_INVALID_STATE);
         }
 
-        ux_flow_init(0, ux_register_data_payload, NULL);
-        *flags |= IO_ASYNCH_REPLY;
+        if (ctx->dataLength == 0) {
+            ux_flow_init(0, ux_register_data_payload, NULL);
+            *flags |= IO_ASYNCH_REPLY;
+        } else {
+            sendSuccessNoIdle();
+        }
     } else {
         THROW(ERROR_INVALID_STATE);
     }

--- a/src/signRegisterData.h
+++ b/src/signRegisterData.h
@@ -21,7 +21,7 @@ typedef enum {
 
 typedef struct {
     uint8_t display[255];
-    uint32_t dataLength;
+    uint16_t dataLength;
     registerDataState_t state;
 } signRegisterData_t;
 


### PR DESCRIPTION
## Purpose

When signing register data, if the `dataBlob` is full size, the first batch is displayed twice.
And fix type of `dataLength`.

## Changes

Only display `dataBlob` when we have received everything.
Change type of `dataLength` to uint16 to reflect actual size.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
