### PR TITLE
Update nanox dependency and use latest build image

### DIFF
--- a/.github/workflows/build-pipeline.yml
+++ b/.github/workflows/build-pipeline.yml
@@ -14,7 +14,7 @@ jobs:
         name: Compile for Nano S
         runs-on: ubuntu-latest
 
-        container: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder:sha-bd9dbbc
+        container: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder:latest
 
         steps:
             - uses: actions/checkout@v2
@@ -37,7 +37,7 @@ jobs:
         name: Compile for Nano X
         runs-on: ubuntu-latest
 
-        container: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder:sha-bd9dbbc
+        container: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder:latest
 
         steps:
             - uses: actions/checkout@v2
@@ -60,7 +60,7 @@ jobs:
         name: Run Clang Static Analyzer
         runs-on: ubuntu-latest
 
-        container: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder:sha-bd9dbbc
+        container: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder:latest
 
         steps:
             - uses: actions/checkout@v2
@@ -125,7 +125,7 @@ jobs:
       runs-on: ubuntu-latest
 
       container:
-        image: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder:sha-bd9dbbc
+        image: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder:latest
 
       steps:
           - name: Clone


### PR DESCRIPTION
## Purpose
Update nanox-secure-sdk dependency and revert to using the latest build image provided by Ledger.

## Changes
- Updated nanox-secure-sdk to commit `1f7a79e88ecaf27f7338fa25d9cd4922b1017af4`.
- Use `latest` ledger builder image.

## Checklist
- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.