### PR TITLE
Bump action versions to avoid deprecation

### DIFF
--- a/.github/workflows/build-pipeline.yml
+++ b/.github/workflows/build-pipeline.yml
@@ -122,7 +122,7 @@ jobs:
                 submodules: 'recursive'
             - run: sudo apt-get update -y && sudo apt-get install -y libusb-1.0.0 libudev-dev
 
-            - uses: actions/setup-node@v2
+            - uses: actions/setup-node@v3
               with:
                 node-version: "14.16.0"
 
@@ -135,7 +135,7 @@ jobs:
                 mkdir tests/bin
 
             - name: Download binaries
-              uses: actions/download-artifact@v2
+              uses: actions/download-artifact@v3
               with:
                 path: tests/bin
 

--- a/.github/workflows/build-pipeline.yml
+++ b/.github/workflows/build-pipeline.yml
@@ -17,7 +17,7 @@ jobs:
         container: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder:sha-229b03c
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
               with:
                   submodules: 'recursive'
 
@@ -28,7 +28,7 @@ jobs:
                   mv bin/app.elf concordium_nanos.elf
 
             - name: Upload binary
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v3
               with:
                 name: nanos
                 path: ./concordium_nanos.elf
@@ -40,7 +40,7 @@ jobs:
         container: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder:sha-229b03c
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
               with:
                   submodules: 'recursive'
 
@@ -51,7 +51,7 @@ jobs:
                   mv bin/app.elf concordium_nanosplus.elf
 
             - name: Upload binary
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v3
               with:
                 name: nanosplus
                 path: ./concordium_nanosplus.elf
@@ -63,7 +63,7 @@ jobs:
         container: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder:sha-229b03c
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
               with:
                   submodules: 'recursive'
 
@@ -74,7 +74,7 @@ jobs:
                   mv bin/app.elf concordium_nanox.elf
 
             - name: Upload binary
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v3
               with:
                 name: nanox
                 path: ./concordium_nanox.elf
@@ -86,7 +86,7 @@ jobs:
         container: ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder:sha-229b03c
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
               with:
                   submodules: 'recursive'
 
@@ -100,7 +100,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
 
             - name: Lint
               uses: DoozyX/clang-format-lint-action@v0.15
@@ -117,7 +117,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
               with:
                 submodules: 'recursive'
             - run: sudo apt-get update -y && sudo apt-get install -y libusb-1.0.0 libudev-dev
@@ -145,7 +145,7 @@ jobs:
 
             - name: Upload snapshots
               if: always()
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v3
               with:
                 name: snapshots
                 path: ./tests/snapshots-tmp
@@ -159,7 +159,7 @@ jobs:
 
       steps:
           - name: Clone
-            uses: actions/checkout@v2
+            uses: actions/checkout@v3
 
           - name: Build unit tests
             run: |


### PR DESCRIPTION
## Purpose
Version 2 of our action dependencies used node 12 which GitHub complains about. This bumps the versions to v3 that should not have this issue.

## Changes
- actions/upload-artifact@v2 --> actions/upload-artifact@v3
- actions/checkout@v2 --> actions/checkout@v3

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.