### PR TITLE
Add support for new paths for verify address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 * Allow export of prfKey, IdCredSec, blinding randomness and attribute commitment randomness using the new paths.
+* Allow verifying an account address using the new paths.
 
 ## 4.0.1
 

--- a/doc/verify_address.md
+++ b/doc/verify_address.md
@@ -7,6 +7,8 @@ Allows the user to approve or reject the address, determining whether the app re
 For an account address to match the one that is displayed, the account's primary credential must be made using the PRF-key exported by the same Ledger on the same identity index and credential counter.
 The address is the credId's sh256 hash, and is displayed in base58.
 
+if P2 = 0x00, then the Legacy path is used. If P2 = 0x01, then the Mainnet path/coinType is used, if P2 = 0x02 then the Testnet path/coinType is used instead. Note that the Legacy path expects only the identity and credCounter, while the other paths also expects the identityProvider index to be given.
+
 ## Protocol description
 
 * Single command
@@ -14,3 +16,6 @@ The address is the credId's sh256 hash, and is displayed in base58.
 INS | P1 | P2 | CDATA | Comment |
 |--------|--------|--------|------------|----|
 | `0x00` | `0x00` | `0x00` | `identity[uint32] credCounter[uint32]` |  |
+| `0x00` | `0x00` | `0x01` | `identityProvider[uint32] identity[uint32] credCounter[uint32]` |  |
+| `0x00` | `0x00` | `0x02` | `identityProvider[uint32] identity[uint32] credCounter[uint32]` |  |
+

--- a/src/main.c
+++ b/src/main.c
@@ -144,7 +144,7 @@ static void concordium_main(void) {
                         handleGetPublicKey(cdata, p1, p2, &flags);
                         break;
                     case INS_VERIFY_ADDRESS:
-                        handleVerifyAddress(cdata, &flags);
+                        handleVerifyAddress(cdata, p2, &flags);
                         break;
                     case INS_SIGN_TRANSFER:
                         handleSignTransfer(cdata, &flags);

--- a/src/verifyAddress.h
+++ b/src/verifyAddress.h
@@ -1,7 +1,7 @@
 #ifndef _CONCORDIUM_APP_VERIFY_ADDRESS_H_
 #define _CONCORDIUM_APP_VERIFY_ADDRESS_H_
 
-void handleVerifyAddress(uint8_t *cdata, volatile unsigned int *flags);
+void handleVerifyAddress(uint8_t *cdata, uint8_t p2, volatile unsigned int *flags);
 
 typedef struct {
     uint8_t display[14];


### PR DESCRIPTION
## Purpose

Support verifying an account address in the browser wallet.

## Changes

`verifyAddress` now uses p2, and p2 = 1,2 uses the new paths for mainnet and testnet, respectively.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

