### PR TITLE
Make governance app choose a different name for zip file

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -143,7 +143,7 @@ endif
 	@echo "python3 -m ledgerblue.deleteApp $(COMMON_DELETE_PARAMS)" >> uninstall.sh
 	@chmod +x uninstall.sh
 	@chmod +x bin/app.hex
-	@zip -r concordium-ledger-app-$(APPVERSION)-$(TARGET_DEVICE)-$(TARGET_VERSION).zip \
+	@zip -r $(APP_FILE_NAME)-$(APPVERSION)-$(TARGET_DEVICE)-$(TARGET_VERSION).zip \
 		licenses \
 		install.bat \
 		loadcertificate.bat \
@@ -158,7 +158,7 @@ endif
 	@rm -f uninstall.sh
 	@rm -f signed_app.apdu
 	@echo
-	@echo "Application was successfully signed and packaged to concordium-ledger-app-$(APPVERSION)-$(TARGET_DEVICE)-$(TARGET_VERSION).zip"
+	@echo "Application was successfully signed and packaged to $(APP_FILE_NAME)-$(APPVERSION)-$(TARGET_DEVICE)-$(TARGET_VERSION).zip"
 
 fail_release_no_public_key:
 	$(error A public key must set as LEDGER_PUBLIC_KEY)

--- a/Makefile.config
+++ b/Makefile.config
@@ -32,6 +32,8 @@ endif
 # Main app configuration
 APPNAME = "Concordium"
 
+APP_FILE_NAME = concordium-ledger-app
+
 # Version must be no greater than 99.99.999, otherwise
 # extra memory must be allocated in menu.c.
 APPVERSION_MAJOR=4

--- a/governance-app/Makefile
+++ b/governance-app/Makefile
@@ -32,6 +32,8 @@ endif
 # Main app configuration
 APPNAME = CCDGovernance
 
+APP_FILE_NAME = concordium-governance-ledger-app
+
 # Version must be no greater than 99.99.999, otherwise
 # extra memory must be allocated in menu.c.
 APPVERSION_MAJOR=1


### PR DESCRIPTION
## Purpose

Governance app release now automatically names the zip folder `concordium-governance-ledger-app...`